### PR TITLE
Remove open/close calls to read/write disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # http-nbd-transfer
 
-Set of tools to transfer NBD requests to a HTTP server:
+Set of tools to transfer NBD requests to an HTTP server:
 
   - `http-disk-server` is used to handle HTTP requests and to read/write in a device.
   - `nbd-server` is used to create a new NBD on the system, and to communicate with one or many HTTP servers.

--- a/http-disk-server
+++ b/http-disk-server
@@ -22,26 +22,54 @@ import argparse
 import errno
 import fcntl
 import os
+import signal
 import socket
 import stat
 import struct
+import subprocess
 import sys
+import threading
 import time
 import traceback
 
 BLKGETSIZE64 = 0x80081272
+BLKFLSBUF = (0x12 << 8) + 97  # Flush buffer cache.
 
-REQ_LIMIT_SIZE = 1024 * 1024 * 128  # In bytes
+REQ_LIMIT_SIZE = 1024 * 1024 * 128  # In bytes.
 
 DRBD_MAJOR = 147
 
-DRBD_OPEN_ATTEMPTS = 100
-DRBD_OPEN_SLEEP_INTERVAL = 0.100  # In seconds.
+DRBD_OPEN_SLEEP = 1.0  # In seconds.
 
 # ==============================================================================
 
+OUTPUT_PREFIX = ''
+
+SIGTERM_RECEIVED = False
+
+def handle_sigterm(*args):
+    global SIGTERM_RECEIVED
+    SIGTERM_RECEIVED = True
+
+# -----------------------------------------------------------------------------
+
+def check_bindable(port):
+    p = subprocess.Popen(
+        ['lsof', '-i:' + str(port), '-Fp'],
+        stdout=subprocess.PIPE,
+        close_fds=True
+    )
+
+    stdout, stderr = p.communicate()
+    if p.returncode:
+        return True
+
+    pid = stdout[1:].rstrip() # remove 'p' before pid
+    eprint('Cannot use port {}, already used by: {}.'.format(port, pid))
+    return False
+
 def eprint(str):
-    print >> sys.stderr, str
+    print >> sys.stderr, OUTPUT_PREFIX + str
 
 def is_drbd_device(path):
     try:
@@ -55,12 +83,12 @@ def open_device(dev_path):
     def cannot_open(e):
         raise Exception('Cannot open device `{}`: `{}`.'.format(dev_path, e))
 
-    attempt = 0
     is_drbd = None
-    while True:
+    while not SIGTERM_RECEIVED:
         try:
-            # Note: Can't use O_DIRECT with DRBD diskless volumes.
-            return os.open(dev_path, os.O_RDWR)
+            disk_fd = os.open(dev_path, os.O_RDWR)
+            eprint('Disk open!')
+            return disk_fd
         except OSError as e:
             if e.errno == errno.EAGAIN or e.errno == errno.EINTR:
                 continue
@@ -71,11 +99,9 @@ def open_device(dev_path):
                 is_drbd = is_drbd_device(dev_path)
             if not is_drbd:
                 cannot_open(e)
-            if attempt >= DRBD_OPEN_ATTEMPTS:
-                raise Exception('Cannot open DRBD device `{}`: `{}`.'.format(dev_path, e))
 
-            attempt += 1
-            time.sleep(DRBD_OPEN_SLEEP_INTERVAL)
+            if not SIGTERM_RECEIVED:
+                time.sleep(DRBD_OPEN_SLEEP)
 
 def close_device(fd):
     if not fd:
@@ -113,7 +139,9 @@ def get_device_size(fd):
             raise
     return disk_capacity
 
-def MakeRequestHandler(disk, disk_capacity):
+# -----------------------------------------------------------------------------
+
+def MakeRequestHandler(disk_fd, is_block_device):
     class RequestHandler(BaseHTTPRequestHandler):
         def __init__(self, *args, **kwargs):
             # Note: We cannot use this call in python 2:
@@ -122,9 +150,12 @@ def MakeRequestHandler(disk, disk_capacity):
             #
             # The base class of `BaseHTTPRequestHandler` uses an old def:
             # "class BaseRequestHandler:"
-            self.disk = disk
-            self.disk_capacity = disk_capacity  # TODO: Detect capacity update?
+            self.disk_fd = disk_fd
+            self.is_block_device = is_block_device
             BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
+
+        def get_content_size(self):
+            return get_device_size(self.disk_fd)
 
         # See: https://stackoverflow.com/questions/6063416/python-basehttpserver-how-do-i-catch-trap-broken-pipe-errors#answer-14355079
         def finish(self):
@@ -150,7 +181,7 @@ def MakeRequestHandler(disk, disk_capacity):
                         values = req_range[1:].lstrip().split('-')
                         begin = int(values[0])
                         end = int(values[1])
-                        if begin <= end and end - begin < self.disk_capacity:
+                        if begin <= end and end - begin < self.get_content_size():
                             return [begin, end - begin + 1]
                     except Exception:
                         pass
@@ -172,7 +203,7 @@ def MakeRequestHandler(disk, disk_capacity):
                     values = req_range.split('-')
                     begin = int(values[0])
                     end = int(values[1].split('/')[0].strip())
-                    if begin <= end and end - begin < self.disk_capacity:
+                    if begin <= end and end - begin < self.get_content_size():
                         return [begin, end - begin + 1]
                 except Exception:
                     pass
@@ -184,7 +215,7 @@ def MakeRequestHandler(disk, disk_capacity):
         def do_HEAD(self):
             self.send_response(200)
             self.send_header('Accept-Ranges', 'bytes')
-            self.send_header('Content-Length', str(self.disk_capacity))
+            self.send_header('Content-Length', str(self.get_content_size()))
             self.end_headers()
 
         def do_GET(self):
@@ -195,22 +226,18 @@ def MakeRequestHandler(disk, disk_capacity):
             offset = req_range[0]
             size = min(req_range[1], REQ_LIMIT_SIZE)
 
-            dev = None
             try:
-                dev = open_device(self.disk)
                 eprint('GET [{}]: Read {}B at {}.'.format(self.client_address[0], size, offset))
-                os.lseek(dev, offset, os.SEEK_SET)
-                chunk = os.read(dev, size)
+                os.lseek(self.disk_fd, offset, os.SEEK_SET)
+                chunk = os.read(self.disk_fd, size)
             except Exception as e:
                 eprint('Can\'t do GET: `{}`.'.format(e))
                 self.send_response(500)
                 self.end_headers()
                 return
-            finally:
-                close_device(dev)
 
             self.send_response(206)
-            self.send_header('Content-Range', 'bytes {}-{}/{}'.format(offset, size - 1, self.disk_capacity))
+            self.send_header('Content-Range', 'bytes {}-{}/{}'.format(offset, size - 1, self.get_content_size()))
             self.send_header('Content-Length', str(int(size)))
             self.end_headers()
 
@@ -224,7 +251,6 @@ def MakeRequestHandler(disk, disk_capacity):
             offset = req_range[0]
             size = req_range[1]
 
-            dev = None
             try:
                 encoding = self.headers.getheader('Transfer-Encoding')
                 if encoding is not None:
@@ -246,17 +272,18 @@ def MakeRequestHandler(disk, disk_capacity):
                     if len(chunk) < size:
                         raise Exception('Truncated chunk!')
 
-                dev = open_device(self.disk)
                 eprint('PUT [{}]: Write {}B at {}.'.format(self.client_address[0], len(chunk), offset))
-                os.lseek(dev, offset, os.SEEK_SET)
-                os.write(dev, chunk)
+                os.lseek(self.disk_fd, offset, os.SEEK_SET)
+                os.write(self.disk_fd, chunk)
+                if self.is_block_device:
+                    fcntl.ioctl(self.disk_fd, BLKFLSBUF)
+                else:
+                    os.fsync(self.disk_fd)
             except Exception as e:
                 eprint('Can\'t do PUT: `{}`.'.format(e))
                 self.send_response(500)
                 self.end_headers()
                 return
-            finally:
-                close_device(dev)
 
             self.send_response(200)
             self.end_headers()
@@ -272,26 +299,60 @@ class HttpDiskServer(HTTPServer):
         self.allow_reuse_address = True
         HTTPServer.__init__(self, *args, **kwargs)
 
-def run_server(disk, disk_capacity, ip, port):
-    HandlerClass = MakeRequestHandler(disk, disk_capacity)
-    httpd = HttpDiskServer((ip or '', port), HandlerClass)
+# -----------------------------------------------------------------------------
 
-    # Must be placed just after the bind call of HTTPServer to notify
-    # parent process that would be waiting before launching NBD server(s).
+def run_server(disk, ip, port):
+    # Check if we can use this port.
+    if not check_bindable(port):
+        return
+
+    # Must be printed to notify parent processes that are waiting
+    # before starting the NBD server(s).
     eprint('Server ready!')
 
-    run = True
-    while run:
+    # Note: `open_device` must be called after the message (never before!)
+    # to ensure we don't block if the device is already open somewhere.
+
+    httpd = None
+    httpd_thread = None
+    disk_fd = None
+    while True:
+        if SIGTERM_RECEIVED:
+            eprint('SIGTERM received. Exiting server...')
+            break
+
         try:
-            httpd.serve_forever()
+            disk_fd = open_device(disk)
+            is_block_device = stat.S_ISBLK(os.fstat(disk_fd).st_mode)
+
+            HandlerClass = MakeRequestHandler(disk_fd, is_block_device)
+            httpd = HttpDiskServer((ip or '', port), HandlerClass)
+            httpd_thread = threading.Thread(target=httpd.serve_forever)
+            httpd_thread.start()
+
+            while not SIGTERM_RECEIVED:
+                signal.pause()
         except KeyboardInterrupt:
-            run = False
+            eprint('Exiting server...')
+            break
+        except Exception as e:
+            eprint('Unhandled exception: `{}`.'.format(e))
+            eprint(traceback.format_exc())
+            eprint('Restarting server...')
+            time.sleep(1)
         finally:
             try:
-                httpd.server_close()
+                if httpd_thread:
+                    httpd.shutdown()
+                    httpd_thread.join()
+                    httpd_thread = None
+                if httpd:
+                    httpd.server_close()
+                    httpd = None
             except Exception as e:
                 eprint('Failed to close server: {}.'.format(e))
-                pass
+            close_device(disk_fd)
+
 
 # ==============================================================================
 
@@ -312,24 +373,10 @@ def main():
     )
 
     args = parser.parse_args()
-
-    # Ensure we can open the device and get size.
-    dev = None
-    try:
-        dev = open_device(args.disk)
-        disk_capacity = get_device_size(dev)
-    finally:
-        close_device(dev)
-
-    if dev and disk_capacity > 0:
-        while True:
-            try:
-                run_server(args.disk, disk_capacity, args.ip, args.port)
-            except Exception as e:
-                eprint('Unhandled exception: `{}`.'.format(e))
-                eprint(traceback.format_exc())
-                eprint('Restarting server...')
-                time.sleep(1)
+    global OUTPUT_PREFIX
+    OUTPUT_PREFIX = '[' + os.path.basename(os.path.realpath(args.disk)) + '] '
+    signal.signal(signal.SIGTERM, handle_sigterm)
+    run_server(args.disk, args.ip, args.port)
 
 if __name__ == '__main__':
     main()

--- a/nbd-http-server
+++ b/nbd-http-server
@@ -29,6 +29,8 @@ NBDKIT_PLUGIN = WORKING_DIR + '../lib64/nbdkit/plugins/nbdkit-multi-http-plugin.
 
 # ==============================================================================
 
+OUTPUT_PREFIX = ''
+
 SIGTERM_RECEIVED = False
 
 def handle_sigterm(*args):
@@ -46,8 +48,23 @@ def pid_exists(pid):
 
 # -----------------------------------------------------------------------------
 
+def remove_file(path):
+    try:
+        os.remove(path)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise e
+
+def run_or_ignore(fun):
+    try:
+        fun()
+    except Exception:
+        pass
+
+# -----------------------------------------------------------------------------
+
 def eprint(str):
-    print >> sys.stderr, str
+    print >> sys.stderr, OUTPUT_PREFIX + str
 
 # -----------------------------------------------------------------------------
 
@@ -82,7 +99,8 @@ def call(cmd, expected_returncode=0):
 # ==============================================================================
 
 class TimeoutException(Exception):
-    pass
+    def __init__(self):
+        super(Exception, self).__init__('timeout')
 
 @contextmanager
 def timeout(seconds):
@@ -100,6 +118,19 @@ def timeout(seconds):
 
 # ==============================================================================
 
+def get_nbd_pid(nbd_path):
+    try:
+        call(['nbd-client', '-c', nbd_path], expected_returncode=1)
+    except CommandException as e:
+        try:
+            return int(e.stdout)
+        except ValueError:
+            return -1
+    return None
+
+def disconnect_nbd(nbd_path):
+    call(['nbd-client', '-d', nbd_path])
+
 class Nbd:
     __slots__ = ('name', 'nbd')
 
@@ -107,13 +138,13 @@ class Nbd:
         self.nbd = nbd
         self.name = name
 
-    def destroy(self):
+    def disconnect(self):
         try:
-            call(['nbd-client', '-d', '/dev/' + self.nbd])
+            disconnect_nbd('/dev/' + self.nbd)
         except Exception as e:
-            eprint('Failed to destroy NBD {}: `{}`.'.format(self.nbd, e))
+            eprint('Failed to disconnect NBD {}: `{}`.'.format(self.nbd, e))
 
-def attach_nbd(socket_path, nbd_name):
+def attach_nbd(socket_path, nbd_name, pid_path):
     def get_nbds():
         return filter(lambda nbd: nbd.startswith('nbd'), os.listdir('/dev'))
 
@@ -135,27 +166,44 @@ def attach_nbd(socket_path, nbd_name):
             continue
 
         # Ensure device is free.
-        try:
-            call(['nbd-client', '-c', nbd_path], expected_returncode=1)
-        except CommandException as e:
-            try:
-                old_pid = int(e.stdout)
-            except ValueError:
-                continue
-
-            if not pid_exists(old_pid):
+        # Also we must do that, otherwise this error can be produced during the attach:
+        # "Ioctl NBD_SET_SOCK failed: Device or resource busy"
+        # And of course, this error kills our server.
+        pid = get_nbd_pid(nbd_path)
+        if pid is not None:
+            if not pid_exists(pid):
                 eprint(
                     'Potential leaked NBD device detected: `{}` used by dead process {}'
-                    .format(nbd_path, old_pid)
+                    .format(nbd_path, pid)
                 )
             continue
 
         # Use free device.
         try:
-            with timeout(5):
+            # Use an extreme timeout here, should never be triggered.
+            with timeout(30):
                 call(['nbd-client', '-unix', socket_path, nbd_path, '-b', '512'])
         except Exception as e:
+            # We guess we have to try another device after that: this exception is probably
+            # caused by a concurrent attach and not with our nbdkit plugin.
             eprint('Failed to attach socket `{}` to {}: {}.'.format(socket_path, nbd_path, e))
+
+            # Ensure the device is still free after failed command.
+            # Note: a race condition exists when we try to release this device,
+            # if the targeted pid is invalid. It can be used by another process.
+            pid = None
+            try:
+                with open(pid_path) as f:
+                    pid = int(f.readline().strip('\n'))
+            except Exception:
+                continue
+            finally:
+                remove_file(pid_path)
+
+            targeted_pid = get_nbd_pid(nbd_path)
+            if (pid is not None and pid == targeted_pid) or targeted_pid < 0:
+                run_or_ignore(lambda: disconnect_nbd(nbd_path))
+
             continue
 
         # NBD is now attached, try to modify scheduler + return NBD object.
@@ -170,40 +218,51 @@ def attach_nbd(socket_path, nbd_name):
 
     raise Exception('Cannot attach `{}` to NBD.'.format(socket_path))
 
-def run_nbd_server(socket_path, nbd_name, urls):
-    try:
-        os.remove(socket_path)
-    except OSError as e:
-        if e.errno != errno.ENOENT:
-            raise e
+def run_nbd_server(socket_path, nbd_name, urls, device_size):
+    pid_path = '/var/run/nbd-{}.pid'.format(nbd_name)
 
-    server = subprocess.Popen([
-        'nbdkit', '--verbose', '--foreground', '-U', socket_path, '-e', nbd_name, NBDKIT_PLUGIN, 'urls=' + urls
-    ])
+    def clean_paths():
+        remove_file(socket_path)
+        remove_file(pid_path)
+
+    clean_paths()
+
+    arguments = [
+        'nbdkit',
+        '--verbose',
+        '--foreground',
+        '-U', socket_path,
+        '-e', nbd_name,
+        '-P', pid_path,
+        NBDKIT_PLUGIN,
+        'urls=' + urls
+    ]
+    if device_size is not None:
+        arguments.append('device-size=' + str(device_size))
+    server = subprocess.Popen(arguments)
     nbd = None
 
     try:
-        nbd = attach_nbd(socket_path, nbd_name)
+        nbd = attach_nbd(socket_path, nbd_name, pid_path)
         # Flush to ensure we can read output (like NBD device used)
         # in another process without waiting.
         sys.stdout.flush()
         sys.stderr.flush()
-        run = True
-        while run:
+        while True:
             try:
                 if SIGTERM_RECEIVED:
                     eprint('SIGTERM received. Exiting server...')
-                    run = False
-                else:
-                    signal.pause()
+                    break
+                signal.pause()
             except KeyboardInterrupt:
                 eprint('Exiting server...')
-                run = False
+                break
     finally:
         if nbd:
-            nbd.destroy()
+            nbd.disconnect()
         server.send_signal(signal.SIGQUIT)
         server.wait()
+        clean_paths()
 
 # ==============================================================================
 
@@ -222,12 +281,17 @@ def main():
         '--urls', action='store', dest='urls', default=None, required=True,
         help='URLS to read/write data'
     )
+    parser.add_argument(
+        '--device-size', action='store', dest='device_size', default=None, required=False, type=int,
+        help='Force the device size, instead of using an HTTP server to get it'
+    )
 
     args = parser.parse_args()
-
+    global OUTPUT_PREFIX
+    OUTPUT_PREFIX = '[' + args.nbd_name + '] '
     try:
         signal.signal(signal.SIGTERM, handle_sigterm)
-        run_nbd_server(args.socket_path, args.nbd_name, args.urls)
+        run_nbd_server(args.socket_path, args.nbd_name, args.urls, args.device_size)
     except Exception as e:
         eprint('Got exception: `{}`.'.format(e))
         exit(1)


### PR DESCRIPTION
- Use a fd descriptor attached to the server instead.
- Regarding DRBD: don't throw in case of failure to open the device if EROFS is returned.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>